### PR TITLE
Remove extra reveal animations

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,4 @@
 window.sr = ScrollReveal({
-  reset: true,
   viewFactor: 0.08,
   scale: .8
 });


### PR DESCRIPTION
In my opinion, the extra animations are unnecessary. This changes it so that elements are only revealed once.