### PR TITLE
Remove weird gridding

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -370,9 +370,6 @@ button:hover {
     margin-left: 5%;
     margin-right: 5%;
   }
-  .top-left {
-    box-shadow: none;
-  }
 }
 
 #faq {
@@ -419,30 +416,6 @@ button:hover {
   border-radius: 5px 5px 9px 9px;
   box-shadow: 0 5px 12px rgba(0,0,0,0.2);
   border-top: solid #5299D3 3px;
-}
-
-@media (max-width: 1030px) and (min-width: 750px) {
-.faq-grid, .ap-grid {
-  align-items: center;
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  -webkit-box-align: center;
-  -webkit-box-pack: justify;
-  max-width: 900px;
-  margin: auto;
-  }
-
-  .faq {
-    display: block;
-  }
-}
-
-@media (max-width: 1030px) and (min-width: 1020px) {
-  .faq-grid, .ap-grid {
-    margin-left: 90px;
-  }
 }
 
 .faq h4 {

--- a/css/index.css
+++ b/css/index.css
@@ -408,7 +408,7 @@ button:hover {
   max-width: 330px;
   background-color: white;
   padding: 16px;
-  height: 240px;
+  height: 250px;
   margin: 15px;
   display: inline-table;
   overflow: hidden;


### PR DESCRIPTION
# Before Fix
## iPad Portrait
![hackchicago io_ ipad](https://user-images.githubusercontent.com/13333578/40281481-74a29032-5c30-11e8-8c96-2b52a6fe6258.png)

## iPad Landscape
![hackchicago io_ ipad 1](https://user-images.githubusercontent.com/13333578/40281489-8b58618a-5c30-11e8-85e6-048bd6b35ca2.png)

# After Fix
## iPad Portrait
![localhost_3000_ ipad](https://user-images.githubusercontent.com/13333578/40281494-aa4627ee-5c30-11e8-806e-53ea51761171.png)
## iPad Landscape
![localhost_3000_ ipad 1](https://user-images.githubusercontent.com/13333578/40281496-b1c64c24-5c30-11e8-91f4-372421074940.png)

I actually have no idea why these weird griddings were initially set for small screen devices. 

![image](https://user-images.githubusercontent.com/13333578/40281516-0599ca1a-5c31-11e8-92e1-8be30ab08737.png)
Shhhhh....
